### PR TITLE
[build] Fixes #27 - Build fixes for Linux.

### DIFF
--- a/base/uikit/core/widget.h
+++ b/base/uikit/core/widget.h
@@ -23,6 +23,8 @@
 #include <style.h>
 #include <plexydesk_ui_exports.h>
 
+#include <functional>
+
 #include <QGraphicsLayoutItem>
 #include <QGraphicsObject>
 

--- a/base/uikit/imagecache.h
+++ b/base/uikit/imagecache.h
@@ -21,11 +21,13 @@
 #ifndef IMAGE_CACHE_H
 #define IMAGE_CACHE_H
 
-#include <QtCore/QObject>
-#include <QtGui/QPainter>
-
 #include <plexy.h>
 #include <plexyconfig.h>
+
+#include <functional>
+
+#include <QObject>
+#include <QPainter>
 
 #include "plexydeskuicore_global.h"
 #include <plexydesk_ui_exports.h>


### PR DESCRIPTION
The build is failing due to missing header file include for
std::functional. This patch fixes the issue for Linux.
